### PR TITLE
Fixed build instructions for standalone build.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ A graphical user interface for monitoring and launching ROS nodes.
 ### Build
 In the project directory run
 ```bash
+export ROS_PACKAGE_PATH=$ROS_PACKAGE_PATH:`pwd`
 make
 ```
 


### PR DESCRIPTION
This package does not build without adding it to the `ROS_PACKAGE_PATH`.